### PR TITLE
Backport of selected bugfixes from the 1.18.6 release to fix the "Flicker" problem

### DIFF
--- a/ext/qt/gstqsgtexture.cc
+++ b/ext/qt/gstqsgtexture.cc
@@ -99,8 +99,6 @@ GstQSGTexture::bind ()
   if (!this->qt_context_)
     return;
 
-  gst_gl_context_activate (this->qt_context_, TRUE);
-
   if (!this->buffer_)
     goto out;
   if (GST_VIDEO_INFO_FORMAT (&this->v_info) == GST_VIDEO_FORMAT_UNKNOWN)
@@ -174,8 +172,6 @@ out:
 
     funcs->glBindTexture (GL_TEXTURE_2D, this->dummy_tex_id_);
   }
-
-  gst_gl_context_activate (this->qt_context_, FALSE);
 }
 
 /* can be called from any thread */

--- a/ext/qt/gstqsgtexture.h
+++ b/ext/qt/gstqsgtexture.h
@@ -38,6 +38,7 @@ public:
 
     void setCaps (GstCaps * caps);
     gboolean setBuffer (GstBuffer * buffer);
+    GstBuffer * getBuffer (gboolean * was_bound);
 
     /* QSGTexture */
     void bind ();
@@ -48,6 +49,7 @@ public:
 
 private:
     GstBuffer * buffer_;
+    gboolean buffer_was_bound;
     GstBuffer * sync_buffer_;
     GstGLContext * qt_context_;
     GstMemory * mem_;

--- a/ext/qt/gstqtsink.cc
+++ b/ext/qt/gstqtsink.cc
@@ -320,6 +320,13 @@ gst_qt_sink_change_state (GstElement * element, GstStateChange transition)
             (NULL));
         return GST_STATE_CHANGE_FAILURE;
       }
+
+      GST_OBJECT_LOCK (qt_sink->display);
+      gst_gl_display_add_context (qt_sink->display, qt_sink->context);
+      GST_OBJECT_UNLOCK (qt_sink->display);
+
+      gst_gl_element_propagate_display_context (GST_ELEMENT (qt_sink), qt_sink->display);
+
       break;
     case GST_STATE_CHANGE_READY_TO_PAUSED:
       break;

--- a/ext/qt/qtitem.cc
+++ b/ext/qt/qtitem.cc
@@ -203,7 +203,9 @@ QtGLVideoItem::updatePaintNode(QSGNode * oldNode,
   GstQSGTexture *tex;
 
   g_mutex_lock (&this->priv->lock);
-  gst_gl_context_activate (this->priv->other_context, TRUE);
+
+  if (gst_gl_context_get_current() == NULL)
+    gst_gl_context_activate (this->priv->other_context, TRUE);
 
   GST_TRACE ("%p updatePaintNode", this);
 
@@ -242,7 +244,6 @@ QtGLVideoItem::updatePaintNode(QSGNode * oldNode,
 
   texNode->setRect (QRectF (result.x, result.y, result.w, result.h));
 
-  gst_gl_context_activate (this->priv->other_context, FALSE);
   g_mutex_unlock (&this->priv->lock);
 
   return texNode;

--- a/ext/qt/qtitem.cc
+++ b/ext/qt/qtitem.cc
@@ -83,6 +83,14 @@ struct _QtGLVideoItemPrivate
   QOpenGLContext *qt_context;
   GstGLContext *other_context;
   GstGLContext *context;
+
+  /* buffers with textures that were bound by QML */
+  GQueue bound_buffers;
+  /* buffers that were previously bound but in the meantime a new one was
+   * bound so this one is most likely not used anymore
+   * FIXME: Ideally we would use fences for this but there seems to be no
+   * way to reliably "try wait" on a fence */
+  GQueue potentially_unbound_buffers;
 };
 
 class InitializeSceneGraph : public QRunnable
@@ -209,6 +217,9 @@ QSGNode *
 QtGLVideoItem::updatePaintNode(QSGNode * oldNode,
     UpdatePaintNodeData * updatePaintNodeData)
 {
+  GstBuffer *old_buffer;
+  gboolean was_bound = FALSE;
+
   if (!m_openGlContextInitialized) {
     return oldNode;
   }
@@ -236,6 +247,38 @@ QtGLVideoItem::updatePaintNode(QSGNode * oldNode,
   }
 
   tex = static_cast<GstQSGTexture *> (texNode->texture());
+
+  if ((old_buffer = tex->getBuffer(&was_bound))) {
+    if (old_buffer == this->priv->buffer) {
+      /* same buffer */
+      gst_buffer_unref (old_buffer);
+    } else if (!was_bound) {
+      GST_TRACE ("old buffer %p was not bound yet, unreffing", old_buffer);
+      gst_buffer_unref (old_buffer);
+    } else {
+      GstBuffer *tmp_buffer;
+
+      GST_TRACE ("old buffer %p was bound, queueing up for later", old_buffer);
+      /* Unref all buffers that were previously not bound anymore. At least
+       * one more buffer was bound in the meantime so this one is most likely
+       * not in use anymore. */
+      while ((tmp_buffer = (GstBuffer*) g_queue_pop_head (&this->priv->potentially_unbound_buffers))) {
+        GST_TRACE ("old buffer %p should be unbound now, unreffing", tmp_buffer);
+        gst_buffer_unref (tmp_buffer);
+      }
+
+      /* Move previous bound buffers to the next queue. We now know that
+       * another buffer was bound in the meantime and will free them on
+       * the next iteration above. */
+      while ((tmp_buffer = (GstBuffer*) g_queue_pop_head (&this->priv->bound_buffers))) {
+        GST_TRACE ("old buffer %p is potentially unbound now", tmp_buffer);
+        g_queue_push_tail (&this->priv->potentially_unbound_buffers, tmp_buffer);
+      }
+      g_queue_push_tail (&this->priv->bound_buffers, old_buffer);
+    }
+    old_buffer = NULL;
+  }
+
   tex->setCaps (this->priv->caps);
   tex->setBuffer (this->priv->buffer);
   texNode->markDirty(QSGNode::DirtyMaterial);
@@ -267,12 +310,23 @@ QtGLVideoItem::updatePaintNode(QSGNode * oldNode,
 static void
 _reset (QtGLVideoItem * qt_item)
 {
+  GstBuffer *tmp_buffer;
+
   gst_buffer_replace (&qt_item->priv->buffer, NULL);
 
   gst_caps_replace (&qt_item->priv->caps, NULL);
 
   qt_item->priv->negotiated = FALSE;
   qt_item->priv->initted = FALSE;
+
+  while ((tmp_buffer = (GstBuffer*) g_queue_pop_head (&qt_item->priv->potentially_unbound_buffers))) {
+    GST_TRACE ("old buffer %p should be unbound now, unreffing", tmp_buffer);
+    gst_buffer_unref (tmp_buffer);
+  }
+  while ((tmp_buffer = (GstBuffer*) g_queue_pop_head (&qt_item->priv->bound_buffers))) {
+    GST_TRACE ("old buffer %p should be unbound now, unreffing", tmp_buffer);
+    gst_buffer_unref (tmp_buffer);
+  }
 }
 
 void

--- a/ext/qt/qtitem.cc
+++ b/ext/qt/qtitem.cc
@@ -150,6 +150,8 @@ QtGLVideoItem::~QtGLVideoItem()
     gst_object_unref(this->priv->other_context);
   if (this->priv->display)
     gst_object_unref(this->priv->display);
+
+  gst_caps_replace (&this->priv->caps, NULL);
   g_free (this->priv);
   this->priv = NULL;
 }

--- a/ext/qt/qtitem.cc
+++ b/ext/qt/qtitem.cc
@@ -31,6 +31,7 @@
 
 #include <QtCore/QRunnable>
 #include <QtCore/QMutexLocker>
+#include <QtCore/QPointer>
 #include <QtGui/QGuiApplication>
 #include <QtQuick/QQuickWindow>
 #include <QtQuick/QSGSimpleTextureNode>
@@ -91,7 +92,7 @@ public:
   void run();
 
 private:
-  QtGLVideoItem *item_;
+  QPointer<QtGLVideoItem> item_;
 };
 
 InitializeSceneGraph::InitializeSceneGraph(QtGLVideoItem *item) :
@@ -101,7 +102,8 @@ InitializeSceneGraph::InitializeSceneGraph(QtGLVideoItem *item) :
 
 void InitializeSceneGraph::run()
 {
-  item_->onSceneGraphInitialized();
+  if(item_)
+    item_->onSceneGraphInitialized();
 }
 
 QtGLVideoItem::QtGLVideoItem()
@@ -292,7 +294,10 @@ QtGLVideoItem::onSceneGraphInitialized ()
   QWindow* window = this->window();
 #endif
 
-  GST_DEBUG ("scene graph initialization with Qt GL context %p",
+  if (this->window() == NULL)
+    return;
+
+  GST_DEBUG ("%p scene graph initialization with Qt GL context %p", this,
       this->window()->openglContext ());
 
   if (this->priv->qt_context == this->window()->openglContext ())

--- a/ext/qt/qtitem.cc
+++ b/ext/qt/qtitem.cc
@@ -137,6 +137,8 @@ QtGLVideoItem::QtGLVideoItem()
 
 QtGLVideoItem::~QtGLVideoItem()
 {
+  GstBuffer *tmp_buffer;
+
   /* Before destroying the priv info, make sure
    * no qmlglsink's will call in again, and that
    * any ongoing calls are done by invalidating the proxy
@@ -152,6 +154,17 @@ QtGLVideoItem::~QtGLVideoItem()
     gst_object_unref(this->priv->other_context);
   if (this->priv->display)
     gst_object_unref(this->priv->display);
+
+  while ((tmp_buffer = (GstBuffer*) g_queue_pop_head (&this->priv->potentially_unbound_buffers))) {
+    GST_TRACE ("old buffer %p should be unbound now, unreffing", tmp_buffer);
+    gst_buffer_unref (tmp_buffer);
+  }
+  while ((tmp_buffer = (GstBuffer*) g_queue_pop_head (&this->priv->bound_buffers))) {
+    GST_TRACE ("old buffer %p should be unbound now, unreffing", tmp_buffer);
+    gst_buffer_unref (tmp_buffer);
+  }
+
+  gst_buffer_replace (&this->priv->buffer, NULL);
 
   gst_caps_replace (&this->priv->caps, NULL);
   g_free (this->priv);


### PR DESCRIPTION
This merges some bugfixes from the official 1.18.6 release to the qgroundcontrol branch. The bugfixes are important for the Android version where a gstreamer pipeline setup will freeze after three video starts when decodebin is used. This shows that these bugfixes are for real bugs...

1.18.6 also introduces some overlay function but I only selected bugfixes which work with the older gstreamer versions which are used in QGC. A full merge of 1.18.6 plugins only works with gestreamer 1.18.6 due to the new overlay functions.

I test this in my qgc repository here: https://github.com/fredowski/qgroundcontrol/pull/8

With these bugfix backports the QGC Video can work again with decodebin and show also the mpegts video formats.  